### PR TITLE
Fix build with gcc 10

### DIFF
--- a/lib/in_wsr/ws_audio.h
+++ b/lib/in_wsr/ws_audio.h
@@ -10,6 +10,6 @@ void ws_audio_port_write(BYTE port,BYTE value);
 BYTE ws_audio_port_read(BYTE port);
 void ws_audio_process(void);
 void ws_audio_sounddma(void);
-int WaveAdrs;
+extern int WaveAdrs;
 
 #endif


### PR DESCRIPTION
Due to https://gcc.gnu.org/gcc-10/porting_to.html#common this addon doesn't build anymore with GCC10. Fix that.